### PR TITLE
Freigabe ohne antragsNummer

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -388,8 +388,8 @@ paths:
           schema:
             type: object
             properties:
-              empfaengerId:
-                $ref: '#/definitions/PartnerID'
+              empfaenger:
+                $ref: '#/definitions/Partner'
                 description: Empfänger dieser Freigabe (Produktanbieter oder Kreditsachbearbeiter)
               antragsNummer:
                 type: string
@@ -791,6 +791,7 @@ definitions:
         description: Unique identifier der freigegebenen Unterlage.
       antragsNummer:
         type: string
+        description: Antragsnummer
       anzeigename:
         type: string
         description: Anzeigename.
@@ -801,7 +802,7 @@ definitions:
         type: string
         format: date-time
         description: Gibt das Datum an, an dem die Unterlage freigegeben wurde.
-      mediatype:
+      mediaType:
         type: string
         description: Media-Type nach https://tools.ietf.org/html/rfc6838.
       kategorie:
@@ -809,11 +810,11 @@ definitions:
         type: string
       bezug:
         $ref: "#/definitions/Bezug"
-      empfaengerId:
-        $ref: "#/definitions/PartnerId"
+      empfaenger:
+        $ref: "#/definitions/Partner"
         description: ProduktAnbieter oder Kreditsachbearbeiter
-      freigebenderId:
-        $ref: "#/definitions/PartnerId"
+      freigebender:
+        $ref: "#/definitions/Partner"
         description: freigebender Vermittler
       abrufstatus:
         $ref: "#/definitions/Abrufstatus"
@@ -852,11 +853,13 @@ definitions:
         items:
           $ref: "#/definitions/FreigegebeneUnterlage"
 
-  PartnerId:
-    type: string
-    description: |
-      Id eines Partners auf der Europace-Plattform. Identifiziert eine Plakette im Partnermanagement.
-    example: ABC45
+  Partner:
+    type: object
+    properties:
+      partnerId:
+        type: string
+        description: Id eines Partners auf der Europace-Plattform. Identifiziert eine Plakette im Partnermanagement.
+        example: ABC45
 
   Relation:
     type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -391,9 +391,8 @@ paths:
               empfaengerId:
                 $ref: '#/definitions/PartnerID'
                 description: Empfänger dieser Freigabe (Produktanbieter oder Kreditsachbearbeiter)
-              referenzNummer:
+              antragsNummer:
                 type: string
-                description: Wird beim Abruf von Freigaben mit zurückgeliefert und dient dem Abrufer zur Zuordnung
               unterlagen:
                 type: array
                 items:
@@ -416,9 +415,9 @@ paths:
          Dieser Endpunkt liefert alle freigegebenen Unterlagen für einen Antrag innerhalb eines Zeitraumes.
       operationId: getFreigegebeneUnterlagen
       parameters:
-      - name: referenzNummer
+      - name: antragsNummer
         in: query
-        description: Die bei der Freigaben übergebene Referenznummer
+        description: Antragsnummer.
         required: false
         type: string
       - name: von
@@ -790,9 +789,8 @@ definitions:
       id:
         type: string
         description: Unique identifier der freigegebenen Unterlage.
-      referenzNummer:
+      antragsNummer:
         type: string
-        description: Die bei der Freigaben übergebene Referenznummer
       anzeigename:
         type: string
         description: Anzeigename.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -388,10 +388,12 @@ paths:
           schema:
             type: object
             properties:
-              produktAnbieter:
+              empfaengerId:
+                $ref: '#/definitions/PartnerID'
+                description: Empfänger dieser Freigabe (Produktanbieter oder Kreditsachbearbeiter)
+              referenzNummer:
                 type: string
-              antragsNummer:
-                type: string
+                description: Wird beim Abruf von Freigaben mit zurückgeliefert und dient dem Abrufer zur Zuordnung
               unterlagen:
                 type: array
                 items:
@@ -414,9 +416,9 @@ paths:
          Dieser Endpunkt liefert alle freigegebenen Unterlagen für einen Antrag innerhalb eines Zeitraumes.
       operationId: getFreigegebeneUnterlagen
       parameters:
-      - name: antragsNummer
+      - name: referenzNummer
         in: query
-        description: Antragsnummer.
+        description: Die bei der Freigaben übergebene Referenznummer
         required: false
         type: string
       - name: von
@@ -788,9 +790,9 @@ definitions:
       id:
         type: string
         description: Unique identifier der freigegebenen Unterlage.
-      antragsNummer:
+      referenzNummer:
         type: string
-        description: Antragsnummer
+        description: Die bei der Freigaben übergebene Referenznummer
       anzeigename:
         type: string
         description: Anzeigename.
@@ -801,19 +803,22 @@ definitions:
         type: string
         format: date-time
         description: Gibt das Datum an, an dem die Unterlage freigegeben wurde.
-      type:
+      mediatype:
         type: string
         description: Media-Type nach https://tools.ietf.org/html/rfc6838.
       kategorie:
         description: Kategorie.
         type: string
-      produktAnbieter:
-        type: string
-        description: ID des ProduktAnbieters.
-      abrufstatus:
-        $ref: "#/definitions/Abrufstatus"
       bezug:
         $ref: "#/definitions/Bezug"
+      empfaengerId:
+        $ref: "#/definitions/PartnerId"
+        description: ProduktAnbieter oder Kreditsachbearbeiter
+      freigebenderId:
+        $ref: "#/definitions/PartnerId"
+        description: freigebender Vermittler
+      abrufstatus:
+        $ref: "#/definitions/Abrufstatus"
       _links:
         type: object
         properties:
@@ -848,6 +853,12 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/FreigegebeneUnterlage"
+
+  PartnerId:
+    type: string
+    description: |
+      Id eines Partners auf der Europace-Plattform. Identifiziert eine Plakette im Partnermanagement.
+    example: ABC45
 
   Relation:
     type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3,7 +3,7 @@ swagger: '2.0'
 info:
   title: Dokumente API
   description: API rund um Plattformdokumente
-  version: "0.14.2"
+  version: "0.14.3"
 host: "dokumente.api.europace.de"
 schemes:
   - https


### PR DESCRIPTION
Session vom 11.Juli.2018

Mit dem API-First-Blick ist aufgefallen, dass unnötig EP-spezifische Konzepte in der Freigabe-API enthalten sind
- antragsNummer => umbenannt zu referenzNummer
- produktAnbieter => wird durch die PartnerId des ProduktAnbieters bzw Kreditentscheiders ersetzt

Desweiteren fehlt (zur Anzeige von Ereignissen im FE) eine Angabe zum Auslöser der Freigabe => freigebenderId