### PR TITLE
Im Rahmen des Loslösens aus der Dokumentenverwaltung muss für freigeg…

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1108,6 +1108,13 @@ definitions:
       filename:
         type: string
         description: Name der Datei.
+      size:
+        type: integer
+        description: Dateigroesse in bytes.
+        format: int64
+      schluessel:
+        type: string
+        description: Oeffentlicher Download Schluessel
       freigabedatum:
         type: string
         format: date-time


### PR DESCRIPTION
…ebene Dokumente genauso wie für nicht freigegebene Dokumente ein oeffentlicher Schluessel zurückgeliefert werden.