### PR TITLE
[DUCK-1178] Erweiterung der Push-Notification-Message um einige Felder

### DIFF
--- a/push-nachrichten/swagger.yaml
+++ b/push-nachrichten/swagger.yaml
@@ -47,6 +47,13 @@ paths:
 
 components:
   schemas:
+    Datenkontext:
+      type: string
+      enum:
+        - TEST_MODUS
+        - ECHT_GESCHAEFT
+      default: ECHT_GESCHAEFT
+
     EventTyp:
       type: string
       enum:
@@ -57,26 +64,37 @@ components:
       properties:
         eventTyp:
           $ref: '#/components/schemas/EventTyp'
+        datenkontext:
+          $ref: '#/components/schemas/Datenkontext'
         unterlagen:
           type: array
           items:
             $ref: '#/components/schemas/Unterlage'
+        produktanbieterId:
+          description: Produktanbieterkennung bei Europace
+          type: string
         antragsNummer:
           type: string
         externeAntragsNummer:
           type: string
       required:
         - eventTyp
+        - datenkontext
         - unterlagen
+        - produktanbieterId
         - antragsNummer
 
     Unterlage:
       type: object
       properties:
+        unterlagenId:
+          description: Id der freigegebenen Unterlage (siehe Unterlagen-API)
+          type: string
         metaDatenUrl:
           type: string
         statusUrl:
           type: string
       required:
+        - unterlagenId
         - metaDatenUrl
         - statusUrl


### PR DESCRIPTION
Erweiterung der Push-Notification-Message um einige Felderr, da diese zur Weiterverarbeitung aus Empfänger-Sicht hilfreich sind

- kein Parsen der URL notwendig, um an die UnterlagenId zu gelangen
- ProduktanbieterId mitgeben für generische Empfänger (die für mehrere PAs ausgelegt sind)

https://europace.atlassian.net/browse/DUCK-1178

!!! erst mergen und releasen, wenn die Änderungen im doctor live gegangen sind, die momentan auf das Aktivieren der Deploy-Pipeline warten !!!