### PR TITLE
Ergänzung der api usecases zu den OAuth scopes in der README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ Erste Schritte zur Nutzung der Europace APIs sind [hier](https://developer.europ
 Bitte benutze [![Authentication](https://img.shields.io/badge/Auth-OAuth2-green)](https://github.com/europace/authorization-api), um Zugang zur API bekommen.
 
 Um die API verwenden zu können, benötigt der OAuth2-Client folgende Scopes:
-`unterlagen:dokument:lesen` \
-`unterlagen:dokument:schreiben` \
-`unterlagen:unterlage:lesen` \
-`unterlagen:unterlage:schreiben` \
-`unterlagen:unterlage:freigeben` \
-`unterlagen:freigabe:lesen` \
-`unterlagen:freigabe:schreiben`
+| Scope                             | API Use case |
+|-----------------------------------|---------------------------------|
+| `unterlagen:dokument:lesen`       | als Vertrieb, Abruf der Metadaten und des Inhalts hochgeladener Dokumente. |
+| `unterlagen:dokument:schreiben`   | als Vertrieb, Hochladen von Dokumenten und Anstoßen der Kategorisierung. Die Kategorisierung muß angestoßen werden, damit nachfolgend die erkannten Unterlagen (kategorisierter Inhalt) freigegeben werden können. Weiterhin das Aktualisieren der Metadaten und Löschen hochgeladener Dokumente.|
+| `unterlagen:unterlage:lesen`      | als Vertrieb, Abruf der Unterlagen(Kategorisierungsinformationen) und der Zuordnungsinformationen zum Vorgang|
+| `unterlagen:unterlage:schreiben`  | als Vertrieb, Ändern Unterlagenkategorie und Zuordnung im Vorgang|
+| `unterlagen:unterlage:freigeben`  | als Vertrieb, Freigabe der Unterlagen für einen Antrag|
+| `unterlagen:freigabe:lesen`       | als Vertrieb und Kreditbetrieb, Abruf der Metadaten und des Inhalts freigegebener Unterlagen zu einem Antrag|
+| `unterlagen:freigabe:schreiben`   | als Kreditbetrieb, nach Verarbeitung der Pushbenachrichtigung einer neuen Freigabe, den Verarbeitungsstatus (Freigabestatus) setzen|
 
 ### TraceId zur Nachverfolgbarkeit von Requests
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Um die API verwenden zu können, benötigt der OAuth2-Client folgende Scopes:
 | `unterlagen:dokument:lesen`       | als Vertrieb, Abruf der Metadaten und des Inhalts hochgeladener Dokumente. |
 | `unterlagen:dokument:schreiben`   | als Vertrieb, Hochladen von Dokumenten und Anstoßen der Kategorisierung. Die Kategorisierung muß angestoßen werden, damit nachfolgend die erkannten Unterlagen (kategorisierter Inhalt) freigegeben werden können. Weiterhin das Aktualisieren der Metadaten und Löschen hochgeladener Dokumente.|
 | `unterlagen:unterlage:lesen`      | als Vertrieb, Abruf der Unterlagen(Kategorisierungsinformationen) und der Zuordnungsinformationen zum Vorgang|
-| `unterlagen:unterlage:schreiben`  | als Vertrieb, Ändern Unterlagenkategorie und Zuordnung im Vorgang|
+| `unterlagen:unterlage:schreiben`  | als Vertrieb, Ändern der Unterlagenkategorie und Zuordnung im Vorgang (Antragsteller, Immobilie, Vorhaben)|
 | `unterlagen:unterlage:freigeben`  | als Vertrieb, Freigabe der Unterlagen für einen Antrag|
 | `unterlagen:freigabe:lesen`       | als Vertrieb und Kreditbetrieb, Abruf der Metadaten und des Inhalts freigegebener Unterlagen zu einem Antrag|
 | `unterlagen:freigabe:schreiben`   | als Kreditbetrieb, nach Verarbeitung der Pushbenachrichtigung einer neuen Freigabe, den Verarbeitungsstatus (Freigabestatus) setzen|


### PR DESCRIPTION
## Motivation
aus BA,KAM,PAM Sicht icht nicht klar, welche Scopes im Partnermanagement zu hinterlegen sind, wenn ein neuer API Client erstellt werden soll. Um das Problem zu lösen, soll die Doku entsprechend erweitert werden.