### PR TITLE
RTM-485 update codeowners

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Closes [DUCK-0000](https://europace.atlassian.net/browse/DUCK-0000)
+Closes [RTM-0000](https://europace.atlassian.net/browse/RTM-0000)
 
 ### Types of changes
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # Bitte die Sortierung dieser Datei beibehalten. Die zuletzt zutreffende Regel
 # hat Vorrang.
 
-* @hypoport/duck
+* @hypoport/rtm


### PR DESCRIPTION
Closes [RTM-485](https://europace.atlassian.net/browse/RTM-485)

Changed codeowners and PR template

[RTM-485]: https://europace.atlassian.net/browse/RTM-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ